### PR TITLE
remove `sorry`-s from `NanoPrecision.DateTime.DateTime`

### DIFF
--- a/Timelib/NanoPrecision/DateTime/DateTime.lean
+++ b/Timelib/NanoPrecision/DateTime/DateTime.lean
@@ -65,11 +65,11 @@ theorem DateTime.val_ne_of_ne : ∀ {d₁ d₂ : DateTime ω} (_ : d₁ ≠ d₂
 
 /-- Compares the underlying naive/TAI DateTime -/
 instance : LT (DateTime ω) where
-  lt := InvImage (instLTNaiveDateTime.lt) DateTime.naive
+  lt := InvImage (NaiveDateTime.instLT.lt) DateTime.naive
 
 /-- Compares the underlying naive/TAI DateTime -/
 instance : LE (DateTime ω) where
-  le := InvImage (instLENaiveDateTime.le) DateTime.naive
+  le := InvImage (NaiveDateTime.instLE.le) DateTime.naive
 
 @[simp] theorem DateTime.le_def (d₁ d₂ : DateTime ω) : (d₁ <= d₂) = (d₁.naive <= d₂.naive) := rfl
 @[simp] theorem DateTime.lt_def (d₁ d₂ : DateTime ω) : (d₁ < d₂) = (d₁.naive < d₂.naive) := rfl

--- a/Timelib/NanoPrecision/DateTime/HDateTime.lean
+++ b/Timelib/NanoPrecision/DateTime/HDateTime.lean
@@ -33,11 +33,12 @@ variable (t : HDateTime)
 def HDateTime.simultaneous : HDateTime → HDateTime → Prop
 | ⟨_, ⟨naive_dt₁⟩⟩, ⟨_, ⟨naive_dt₂⟩⟩ => naive_dt₁ = naive_dt₂
 
-def HDateTime.simultaneous.equivalence : Equivalence HDateTime.simultaneous :=  {
-  refl := fun d => rfl
-  symm := fun h => h.symm
-  trans := fun h h' => Eq.trans h h'
-}
+def HDateTime.simultaneous.equivalence :
+  Equivalence HDateTime.simultaneous
+where
+  refl _d := rfl
+  symm h := h.symm
+  trans h h' := Eq.trans h h'
 
 instance instHDateTimeSetoid : Setoid HDateTime :=
   ⟨HDateTime.simultaneous, HDateTime.simultaneous.equivalence⟩
@@ -46,13 +47,13 @@ instance instHDateTimeSetoid : Setoid HDateTime :=
 LT compares the underlying naive DateTime.
 -/
 instance : LT HDateTime where
-  lt := InvImage instLTNaiveDateTime.lt (fun t => t.dateTime.naive)
+  lt := InvImage NaiveDateTime.instLT.lt (fun t => t.dateTime.naive)
 
 /--
 LE compares the underlying naive DateTime
 -/
 instance : LE HDateTime where
-  le := InvImage instLENaiveDateTime.le (fun t => t.dateTime.naive)
+  le := InvImage NaiveDateTime.instLE.le (fun t => t.dateTime.naive)
 
 @[simp] theorem HDateTime.le_def (d₁ d₂ : HDateTime) : (d₁ <= d₂) = (d₁.dateTime.naive <= d₂.dateTime.naive) := rfl
 @[simp] theorem HDateTime.lt_def (d₁ d₂ : HDateTime) : (d₁ < d₂) = (d₁.dateTime.naive < d₂.dateTime.naive) := rfl
@@ -65,9 +66,9 @@ HDateTime is only a Preorder since it does not respect antisymmetry.
 t₁ <= t₂ ∧ t₂ <= t₁ does not imply t₁ = t₂ since they may have different offets/timezones.
 -/
 instance : Preorder HDateTime where
-  le_refl (a) := le_refl a.dateTime.naive
-  le_trans (a b c) := Int.le_trans
-  lt_iff_le_not_le (a b) := Int.lt_iff_le_not_le
+  le_refl a := le_refl a.dateTime.naive
+  le_trans _a _b _c := Int.le_trans
+  lt_iff_le_not_le _a _b := Int.lt_iff_le_not_le
 
 instance : HAdd HDateTime SignedDuration HDateTime where
   hAdd da du := ⟨da.offset, da.dateTime + du⟩

--- a/Timelib/NanoPrecision/DateTime/NaiveDateTime.lean
+++ b/Timelib/NanoPrecision/DateTime/NaiveDateTime.lean
@@ -86,13 +86,13 @@ theorem eq_def : ∀ {d1 d2 : NaiveDateTime},
 
 theorem val_ne_of_ne : ∀ {d1 d2 : NaiveDateTime},
   d1 ≠ d2 → d1.nanos ≠ d2.nanos
-| ⟨x⟩, ⟨y⟩, h => by intro hh; apply h; exact congrArg NaiveDateTime.mk hh
+| ⟨x⟩, ⟨y⟩, h => by intro hh; apply h; exact congrArg mk hh
 
 instance instLT : LT NaiveDateTime where
-  lt := InvImage Int.lt NaiveDateTime.nanos
+  lt := InvImage Int.lt nanos
 
 instance instLE : LE NaiveDateTime where
-  le := InvImage Int.le NaiveDateTime.nanos
+  le := InvImage Int.le nanos
 
 @[simp] theorem le_def (d₁ d₂ : NaiveDateTime) :
   (d₁ <= d₂) = (d₁.nanos <= d₂.nanos)
@@ -115,13 +115,12 @@ instance instLinearOrder : LinearOrder NaiveDateTime where
   le_trans (a b c) := Int.le_trans
   lt_iff_le_not_le (a b) := Int.lt_iff_le_not_le
   le_antisymm (a b h1 h2) := by
-    apply NaiveDateTime.eq_of_val_eq
+    apply eq_of_val_eq
     exact le_antisymm h1 h2
-  le_total := by simp [NaiveDateTime.le_def, le_total]
+  le_total := by simp [le_def, le_total]
   decidableLE := inferInstance
   compare_eq_compareOfLessAndEq := by
-    simp [compare, compareOfLessAndEq,
-      NaiveDateTime.lt_def, NaiveDateTime.eq_def]
+    simp [compare, compareOfLessAndEq, lt_def, eq_def]
 
 def seconds (d : NaiveDateTime) : Int := d.nanos / oneSecondNanos
 

--- a/Timelib/NanoPrecision/DateTime/NaiveDateTime.lean
+++ b/Timelib/NanoPrecision/DateTime/NaiveDateTime.lean
@@ -20,64 +20,97 @@ If negative, the number of nanoseconds until the epoch (midnight of 0001/Jan/01)
 -/
 structure NaiveDateTime where
   nanos : Int
-deriving DecidableEq, Ord, Hashable, Repr, Lean.ToJson, Lean.FromJson
+deriving DecidableEq, Hashable, Repr, Lean.ToJson, Lean.FromJson
 
-instance : Inhabited NaiveDateTime where
+
+
+namespace NaiveDateTime
+
+
+
+instance instInhabited : Inhabited NaiveDateTime where
   default := ⟨0⟩
+
+instance instOrd : Ord NaiveDateTime where
+  compare l r := compare l.nanos r.nanos
 
 /-
 Using `Int.fdiv`, because we have a positive denominator, and we want to round
 down if `dt.nanos` is negative, up if it's nonnegative.
 -/
-def NaiveDateTime.toScalarDate (dt : NaiveDateTime) : ScalarDate := ⟨(dt.nanos.fdiv oneDayNanos) + 1⟩
+def toScalarDate (dt : NaiveDateTime) : ScalarDate :=
+  ⟨(dt.nanos.fdiv oneDayNanos) + 1⟩
 
-def NaiveDateTime.dayOfWeek (dt : NaiveDateTime) : Int := dt.toScalarDate.dayOfWeek
+def dayOfWeek (dt : NaiveDateTime) : Int :=
+  dt.toScalarDate.dayOfWeek
 
-/--
-The `DateTime` as of midnight (00:00:00 uninterpreted) on the ymd.
-We subtract one to account for the fact that `Date` is one day ahead of the zero-based `NaiveDateTime`.
+/-- The `DateTime` as of midnight (00:00:00 uninterpreted) on the ymd. We
+subtract one to account for the fact that `Date` is one day ahead of the
+zero-based `NaiveDateTime`.
 -/
-def NaiveDateTime.fromYmd
+def fromYmd
   (y : Year)
   (m : Month)
   (d : Nat)
-  (hd : 1 <= d ∧ d <= m.numDays y := by decide) : NaiveDateTime :=
-    ⟨oneDayNanos * ((Ymd.mk y m d hd.left hd.right).toScalarDate.day - 1)⟩
+  (hd : 1 <= d ∧ d <= m.numDays y := by decide)
+: NaiveDateTime :=
+  ⟨oneDayNanos * ((Ymd.mk y m d hd.left hd.right).toScalarDate.day - 1)⟩
 
-def NaiveDateTime.fromYmdsn
+def fromYmdsn
   (y : Year)
   (m : Month)
   (d : Nat)
   (s : Nat)
   (n : Nat)
-  (hd : 1 <= d ∧ d <= m.numDays y := by decide) : NaiveDateTime :=
-    ⟨(NaiveDateTime.fromYmd y m d hd).nanos + (oneSecondNanos * s) + n⟩
+  (hd : 1 <= d ∧ d <= m.numDays y := by decide)
+: NaiveDateTime :=
+  ⟨(fromYmd y m d hd).nanos + (oneSecondNanos * s) + n⟩
 
-instance : Equiv Int NaiveDateTime where
-  toFun := NaiveDateTime.mk
-  invFun := NaiveDateTime.nanos
+instance instEquivIntSelf : Equiv Int NaiveDateTime where
+  toFun := mk
+  invFun := nanos
   left_inv := by simp [Function.LeftInverse]
   right_inv := by simp [Function.LeftInverse, Function.RightInverse]
 
-theorem NaiveDateTime.eq_of_val_eq : ∀ {d1 d2 : NaiveDateTime} (h : d1.nanos = d2.nanos), d1 = d2
+theorem eq_of_val_eq : ∀ {d1 d2 : NaiveDateTime},
+  d1.nanos = d2.nanos → d1 = d2
 | ⟨_⟩, _, rfl => rfl
 
-theorem NaiveDateTime.val_ne_of_ne : ∀ {d1 d2 : NaiveDateTime} (h : d1 ≠ d2), d1.nanos ≠ d2.nanos
+theorem val_eq_of_eq : ∀ {d1 d2 : NaiveDateTime},
+  d1 = d2 → d1.nanos = d2.nanos
+| ⟨_⟩, _, rfl => rfl
+
+theorem eq_def : ∀ {d1 d2 : NaiveDateTime},
+  d1 = d2 ↔ d1.nanos = d2.nanos
+:= ⟨val_eq_of_eq, eq_of_val_eq⟩
+
+theorem val_ne_of_ne : ∀ {d1 d2 : NaiveDateTime},
+  d1 ≠ d2 → d1.nanos ≠ d2.nanos
 | ⟨x⟩, ⟨y⟩, h => by intro hh; apply h; exact congrArg NaiveDateTime.mk hh
 
-instance : LT NaiveDateTime where
+instance instLT : LT NaiveDateTime where
   lt := InvImage Int.lt NaiveDateTime.nanos
 
-instance : LE NaiveDateTime where
+instance instLE : LE NaiveDateTime where
   le := InvImage Int.le NaiveDateTime.nanos
 
-@[simp] theorem NaiveDateTime.le_def (d₁ d₂ : NaiveDateTime) : (d₁ <= d₂) = (d₁.nanos <= d₂.nanos) := rfl
-@[simp] theorem NaiveDateTime.lt_def (d₁ d₂ : NaiveDateTime) : (d₁ < d₂) = (d₁.nanos < d₂.nanos) := rfl
+@[simp] theorem le_def (d₁ d₂ : NaiveDateTime) :
+  (d₁ <= d₂) = (d₁.nanos <= d₂.nanos)
+:= rfl
 
-instance instDecidableLENaiveDateTime (d₁ d₂ : NaiveDateTime) : Decidable (d₁ <= d₂) := inferInstanceAs (Decidable <| d₁.nanos <= d₂.nanos)
-instance instDecidableLTNaiveDateTime (d₁ d₂ : NaiveDateTime) : Decidable (d₁ < d₂) := inferInstanceAs (Decidable <| d₁.nanos < d₂.nanos)
+@[simp] theorem lt_def (d₁ d₂ : NaiveDateTime) :
+  (d₁ < d₂) = (d₁.nanos < d₂.nanos)
+:= rfl
 
-instance : LinearOrder NaiveDateTime where
+instance instDecidableLENaiveDateTime (d₁ d₂ : NaiveDateTime) :
+  Decidable (d₁ <= d₂)
+:= inferInstanceAs (Decidable <| d₁.nanos <= d₂.nanos)
+
+instance instDecidableLTNaiveDateTime (d₁ d₂ : NaiveDateTime) :
+  Decidable (d₁ < d₂)
+:= inferInstanceAs (Decidable <| d₁.nanos < d₂.nanos)
+
+instance instLinearOrder : LinearOrder NaiveDateTime where
   le_refl (a) := le_refl a.nanos
   le_trans (a b c) := Int.le_trans
   lt_iff_le_not_le (a b) := Int.lt_iff_le_not_le
@@ -86,89 +119,133 @@ instance : LinearOrder NaiveDateTime where
     exact le_antisymm h1 h2
   le_total := by simp [NaiveDateTime.le_def, le_total]
   decidableLE := inferInstance
-  compare_eq_compareOfLessAndEq := by sorry
+  compare_eq_compareOfLessAndEq := by
+    simp [compare, compareOfLessAndEq,
+      NaiveDateTime.lt_def, NaiveDateTime.eq_def]
 
-def NaiveDateTime.seconds (d : NaiveDateTime) : Int := d.nanos / oneSecondNanos
+def seconds (d : NaiveDateTime) : Int := d.nanos / oneSecondNanos
 
-def NaiveDateTime.fromNanos : Int → NaiveDateTime := NaiveDateTime.mk
+def fromNanos : Int → NaiveDateTime := mk
 
-def NaiveDateTime.toYmd (d : NaiveDateTime) : Ymd := d.toScalarDate.toYmd
+def toYmd (d : NaiveDateTime) : Ymd := d.toScalarDate.toYmd
 
-def NaiveDateTime.year (d : NaiveDateTime) : Year := d.toScalarDate.year
+def year (d : NaiveDateTime) : Year := d.toScalarDate.year
 
-instance : ToString NaiveDateTime where
+instance instToString : ToString NaiveDateTime where
   toString dt :=
     let ⟨y, m, d, _, _⟩ := dt.toYmd
-    let t : String := ToString.toString <| NaiveClockTime.mk (Fin.ofInt'' (dt.nanos % (↑oneDayNanos)))
+    let t : String :=
+      Fin.ofInt'' (dt.nanos % (↑oneDayNanos))
+      |> NaiveClockTime.mk
+      |> ToString.toString
     s!"{y}/{m.toNat}/{d}; {t}"
 
 @[reducible]
-def NaiveDateTime.dateEq : NaiveDateTime → NaiveDateTime → Prop
+def dateEq : NaiveDateTime → NaiveDateTime → Prop
 | n₁, n₂ => n₁.toScalarDate = n₂.toScalarDate
 
-def NaiveDateTime.dateEq.Equivalence : Equivalence NaiveDateTime.dateEq := {
+def dateEq.Equivalence : Equivalence dateEq := {
   refl := fun _ => rfl
   symm := fun h => h.symm
   trans := fun h h' => Eq.trans h h'
 }
 
 instance instNaiveDateTimeSetoid : Setoid NaiveDateTime :=
-  ⟨NaiveDateTime.dateEq, NaiveDateTime.dateEq.Equivalence⟩
+  ⟨dateEq, dateEq.Equivalence⟩
 
-instance (d₁ d₂ : NaiveDateTime) : Decidable <| d₁.dateEq d₂ := inferInstance
+instance instDecidable_dateEq (d₁ d₂ : NaiveDateTime) :
+  Decidable <| d₁.dateEq d₂
+:= inferInstance
 
-instance {n : Nat} : OfNat NaiveDateTime n where
+instance instOfNat {n : Nat} : OfNat NaiveDateTime n where
   ofNat := ⟨n⟩
 
-instance : HAdd NaiveDateTime SignedDuration NaiveDateTime where
+instance instHAddSelfSignedDurationSelf :
+  HAdd NaiveDateTime SignedDuration NaiveDateTime
+where
   hAdd da du := ⟨da.nanos + du.val⟩
 
-instance : HAdd SignedDuration NaiveDateTime NaiveDateTime where
+instance instHAddSignedDurationSelfSelf :
+  HAdd SignedDuration NaiveDateTime NaiveDateTime
+where
   hAdd du da := da + du
 
-theorem NaiveDateTime.hAdd_signed_def (d : NaiveDateTime) (dur : SignedDuration) : d + dur = ⟨d.nanos + dur.val⟩ := rfl
-theorem NaiveDateTime.hAdd_signed_def_rev (d : NaiveDateTime) (dur : SignedDuration) : dur + d = ⟨d.nanos + dur.val⟩ := rfl
+theorem hAdd_signed_def (d : NaiveDateTime) (dur : SignedDuration) :
+  d + dur = ⟨d.nanos + dur.val⟩
+:= rfl
+theorem hAdd_signed_def_rev (d : NaiveDateTime) (dur : SignedDuration) :
+  dur + d = ⟨d.nanos + dur.val⟩
+:= rfl
 
-instance : HSub NaiveDateTime SignedDuration NaiveDateTime where
+instance instHSubSelfSignedDurationSelf :
+  HSub NaiveDateTime SignedDuration NaiveDateTime
+where
   hSub t dur := t + -dur
 
-theorem NaiveDateTime.hSub_signed_def (d : NaiveDateTime) (dur : SignedDuration) : d - dur = d + -dur := rfl
+theorem hSub_signed_def (d : NaiveDateTime) (dur : SignedDuration) :
+  d - dur = d + -dur
+:= rfl
 
-theorem NaiveDateTime.hAdd_signed_sub_cancel (t : NaiveDateTime) (d : SignedDuration) : t + d - d = t := by
-  apply NaiveDateTime.eq_of_val_eq
-  simp [NaiveDateTime.hSub_signed_def, NaiveDateTime.hAdd_signed_def]
+theorem hAdd_signed_sub_cancel (t : NaiveDateTime) (d : SignedDuration) :
+  t + d - d = t
+:= by
+  apply eq_of_val_eq
+  simp [hSub_signed_def, hAdd_signed_def]
   apply Int.add_neg_cancel_right
 
-theorem NaiveDateTime.hAdd_signed_sub_add_cancel (t : NaiveDateTime) (d : SignedDuration) : t - d + d = t := by
-  simp [NaiveDateTime.hSub_signed_def, NaiveDateTime.hAdd_signed_def]
-  exact NaiveDateTime.eq_of_val_eq (Int.sub_add_cancel t.nanos d.val)
+theorem hAdd_signed_sub_add_cancel (t : NaiveDateTime) (d : SignedDuration) :
+  t - d + d = t
+:= by
+  simp [hSub_signed_def, hAdd_signed_def]
+  exact eq_of_val_eq (Int.sub_add_cancel t.nanos d.val)
 
-theorem NaiveDateTime.hAdd_signed_comm (t : NaiveDateTime) (d : SignedDuration) : t + d = d + t := by
-  simp [NaiveDateTime.hAdd_signed_def, NaiveDateTime.hAdd_signed_def_rev]
+theorem hAdd_signed_comm (t : NaiveDateTime) (d : SignedDuration) :
+  t + d = d + t
+:= by
+  simp [hAdd_signed_def, hAdd_signed_def_rev]
 
-instance : HAdd NaiveDateTime UnsignedDuration NaiveDateTime where
+instance instHAddSelfUnsignedDurationSelf :
+  HAdd NaiveDateTime UnsignedDuration NaiveDateTime
+where
   hAdd da du := ⟨da.nanos + du.val⟩
 
-instance : HAdd UnsignedDuration NaiveDateTime NaiveDateTime where
+instance instHAddUnsignedDurationSelfSelf :
+  HAdd UnsignedDuration NaiveDateTime NaiveDateTime
+where
   hAdd du da := da + du
 
-theorem NaiveDateTime.hAdd_unsigned_def (d : NaiveDateTime) (dur : UnsignedDuration) : d + dur = ⟨d.nanos + dur.val⟩ := rfl
+theorem hAdd_unsigned_def (d : NaiveDateTime) (dur : UnsignedDuration) :
+  d + dur = ⟨d.nanos + dur.val⟩
+:= rfl
 
-instance : HSub NaiveDateTime UnsignedDuration NaiveDateTime where
+instance instHSubSelfUnsignedDurationSelf :
+  HSub NaiveDateTime UnsignedDuration NaiveDateTime
+where
   hSub da du := ⟨da.nanos - du.val⟩
 
-theorem NaiveDateTime.hSub_unsigned_def (d : NaiveDateTime) (dur : UnsignedDuration) : d - dur = ⟨d.nanos - dur.val⟩ := rfl
+theorem hSub_unsigned_def (d : NaiveDateTime) (dur : UnsignedDuration) :
+  d - dur = ⟨d.nanos - dur.val⟩
+:= rfl
 
-theorem NaiveDateTime.hAdd_unsigned_sub_cancel (t : NaiveDateTime) (d : UnsignedDuration) : t + d - d = t := NaiveDateTime.hAdd_signed_sub_cancel t d
+theorem hAdd_unsigned_sub_cancel (t : NaiveDateTime) (d : UnsignedDuration) :
+  t + d - d = t
+:= hAdd_signed_sub_cancel t d
 
-theorem NaiveDateTime.hAdd_unsigned_sub_add_cancel (t : NaiveDateTime) (d : UnsignedDuration) : t - d + d = t := NaiveDateTime.hAdd_signed_sub_add_cancel t d
+theorem hAdd_unsigned_sub_add_cancel
+  (t : NaiveDateTime) (d : UnsignedDuration)
+: t - d + d = t
+:= hAdd_signed_sub_add_cancel t d
 
-theorem NaiveDateTime.hAdd_unsigned_comm (t : NaiveDateTime) (d : UnsignedDuration) : t + d = d + t := NaiveDateTime.hAdd_signed_comm t d
+theorem hAdd_unsigned_comm (t : NaiveDateTime) (d : UnsignedDuration) :
+  t + d = d + t
+:= hAdd_signed_comm t d
 
 /--
 Set the clock time of the current day to `tgt`.
 -/
 @[reducible]
-def NaiveDateTime.setClockTime (t : NaiveDateTime) (clockTime : NaiveClockTime) : NaiveDateTime :=
+def setClockTime (t : NaiveDateTime) (clockTime : NaiveClockTime) :
+  NaiveDateTime
+:=
   let days := (t.nanos.fdiv oneDayNanos) * oneDayNanos
   ⟨days + clockTime.nanos.val⟩


### PR DESCRIPTION
- added a `eq_def` lemma
- removed the sorry in the `compare_eq_compareOfLessAndEq` from `LinearOrder`
- improved presentation
- line wrap 80
- fixed warnings in `DateTime`, and a few others

I had to write an `Ord NaiveDateTime` instance manually. I'm not sure why, but I could not get the derived version to unfold in the proof of `compare_eq_compareOfLessAndEq`.

I don't know what the derived instance does exactly, I assume it's the same as my instance. Let me know if having this manual instance is a problem.

> Note that the *manual `Ord` instance + `eq_def`* pattern allows to prove many (but not all) of the missing `compare_eq_compareOfLessAndEq` proofs.