### PR TITLE
proofs and formatting on `ClockTime` files

### DIFF
--- a/Timelib/NanoPrecision/ClockTime/HClockTime.lean
+++ b/Timelib/NanoPrecision/ClockTime/HClockTime.lean
@@ -78,13 +78,13 @@ theorem HClockTime.unapply_apply : t - t.timeZone.offset + t.timeZone.offset = t
 LT compares the underlying naive/TAI time.
 -/
 instance : LT HClockTime where
-  lt := InvImage instLTNaiveClockTime.lt (fun t => t.clockTime.naive)
+  lt := InvImage NaiveClockTime.instLT.lt (fun t => t.clockTime.naive)
 
 /--
 LE compares the underlying naive/TAI time.
 -/
 instance : LE HClockTime where
-  le := InvImage instLENaiveClockTime.le (fun t => t.clockTime.naive)
+  le := InvImage NaiveClockTime.instLE.le (fun t => t.clockTime.naive)
 
 theorem HClockTime.le_def (d₁ d₂ : HClockTime) : (d₁ <= d₂) = (d₁.clockTime.naive <= d₂.clockTime.naive) := rfl
 theorem HClockTime.lt_def (d₁ d₂ : HClockTime) : (d₁ < d₂) = (d₁.clockTime.naive < d₂.clockTime.naive) := rfl
@@ -97,8 +97,8 @@ HClockTime is only a Preorder since it does not respect antisymmetry.
 t₁ <= t₂ ∧ t₂ <= t₁ does not imply t₁ = t₂ since they may have different timezones.
 -/
 instance : Preorder HClockTime where
-  le_refl (a) := le_refl a.clockTime.naive
-  le_trans (a b c) := Nat.le_trans
-  lt_iff_le_not_le (a b) := Nat.lt_iff_le_not_le
+  le_refl a := le_refl a.clockTime.naive
+  le_trans _a _b _c := Nat.le_trans
+  lt_iff_le_not_le _a _b := Nat.lt_iff_le_not_le
 
 end HClockTimeStuff

--- a/Timelib/NanoPrecision/ClockTime/HClockTime.lean
+++ b/Timelib/NanoPrecision/ClockTime/HClockTime.lean
@@ -13,92 +13,117 @@ import Timelib.NanoPrecision.Duration.UnsignedDuration
 import Timelib.NanoPrecision.Duration.SignedDuration
 import Timelib.NanoPrecision.ClockTime.ClockTime
 
+
+
 structure HClockTime where
   timeZone : TimeZone
   clockTime : ClockTime timeZone
 
-def HClockTime.EquivSigma : Equiv HClockTime (Sigma ClockTime) := {
-  toFun := fun oct => ⟨oct.timeZone, oct.clockTime⟩
-  invFun := fun sig => ⟨sig.fst, sig.snd⟩
+
+
+namespace HClockTime
+
+
+
+def EquivSigma : Equiv HClockTime (Sigma ClockTime) where
+  toFun oct := ⟨oct.timeZone, oct.clockTime⟩
+  invFun sig := ⟨sig.fst, sig.snd⟩
   left_inv := by simp [Function.LeftInverse]
   right_inv := by simp [Function.RightInverse, Function.LeftInverse]
-}
 
-section HClockTimeStuff
 
-variable (t : HClockTime)
 
 @[reducible]
-def HClockTime.simultaneous : HClockTime → HClockTime → Prop
+def simultaneous : HClockTime → HClockTime → Prop
 | ⟨_, ⟨naive_t₁⟩⟩, ⟨_, ⟨naive_t₂⟩⟩ => naive_t₁ = naive_t₂
 
-def HClockTime.simultaneous.equivalence : Equivalence HClockTime.simultaneous :=  {
-  refl := fun d => rfl
-  symm := fun h => h.symm
-  trans := fun h h' => Eq.trans h h'
-}
+def simultaneous.equivalence : Equivalence HClockTime.simultaneous where
+  refl _d := rfl
+  symm h := h.symm
+  trans h h' := Eq.trans h h'
 
-instance instHClockTimeSetoid : Setoid HClockTime := ⟨HClockTime.simultaneous, HClockTime.simultaneous.equivalence⟩
 
-instance : Inhabited <| HClockTime := ⟨TimeZone.UTC, Inhabited.default⟩
 
-def HClockTime.nanoComponent : Nat := t.clockTime.nanoComponent
-def HClockTime.secondComponent : Nat := t.clockTime.secondComponent
-def HClockTime.minuteComponent : Nat := t.clockTime.minuteComponent
-def HClockTime.hourComponent : Nat := t.clockTime.hourComponent
+instance instSetoid : Setoid HClockTime :=
+  ⟨HClockTime.simultaneous, HClockTime.simultaneous.equivalence⟩
+
+instance instInhabited : Inhabited <| HClockTime :=
+  ⟨TimeZone.UTC, default⟩
+
+
+
+section
+  variable (t : HClockTime)
+
+  def nanoComponent   : Nat := t.clockTime.nanoComponent
+  def secondComponent : Nat := t.clockTime.secondComponent
+  def minuteComponent : Nat := t.clockTime.minuteComponent
+  def hourComponent   : Nat := t.clockTime.hourComponent
+end
+
+
 
 /--
 Addition of a `Duration` to a `ClockTime`; wraps into the next clock cycle.
 -/
-instance : HAdd HClockTime SignedDuration HClockTime where
+instance instHAddSelfSignedDurationSelf :
+  HAdd HClockTime SignedDuration HClockTime
+where
   hAdd t d := { t with clockTime := t.clockTime + d }
 
-theorem HClockTime.hAdd_signed_def (dur : SignedDuration) : t + dur = { t with clockTime := t.clockTime + dur } := rfl
-
-/--
-Subtraction of a `SignedDuration` from a `ClockTime`; the implementation follows
-that of `Fin oneDayNanos`, wrapping into the previous clock cycle on underflow
--/
-instance : HSub HClockTime SignedDuration HClockTime where
+/-- Subtraction of a `SignedDuration` from a `ClockTime`; the implementation
+follows that of `Fin oneDayNanos`, wrapping into the previous clock cycle on
+underflow. -/
+instance instHSubSelfSignedDurationSelf :
+  HSub HClockTime SignedDuration HClockTime
+where
   hSub t d := { t with clockTime := t.clockTime - d }
 
-theorem HClockTime.hSub_signed_def (dur : SignedDuration) : t - dur = { t with clockTime := t.clockTime - dur } := rfl
+section
+  variable (t : HClockTime) (d : SignedDuration)
 
-theorem HClockTime.apply_unapply : t + t.timeZone.offset - t.timeZone.offset = t := by
-  simp [HClockTime.hAdd_signed_def, HClockTime.hSub_signed_def]
-  rw [HClockTime.mk.injEq]
-  exact And.intro rfl (heq_of_eq (ClockTime.apply_unapply t.clockTime))
+  theorem hAdd_signed_def : t + d = { t with clockTime := t.clockTime + d } :=
+    rfl
 
-theorem HClockTime.unapply_apply : t - t.timeZone.offset + t.timeZone.offset = t := by
-  simp [HClockTime.hAdd_signed_def, HClockTime.hSub_signed_def]
-  rw [HClockTime.mk.injEq]
-  exact And.intro rfl (heq_of_eq (ClockTime.unapply_apply t.clockTime))
+  theorem hSub_signed_def : t - d = { t with clockTime := t.clockTime - d } :=
+    rfl
 
-/--
-LT compares the underlying naive/TAI time.
--/
-instance : LT HClockTime where
+  theorem apply_unapply : t + t.timeZone.offset - t.timeZone.offset = t := by
+    simp [HClockTime.hAdd_signed_def, HClockTime.hSub_signed_def]
+    rw [HClockTime.mk.injEq]
+    exact And.intro rfl (heq_of_eq $ ClockTime.apply_unapply t.clockTime)
+
+  theorem unapply_apply : t - t.timeZone.offset + t.timeZone.offset = t := by
+    simp [HClockTime.hAdd_signed_def, HClockTime.hSub_signed_def]
+    rw [HClockTime.mk.injEq]
+    exact And.intro rfl (heq_of_eq $ ClockTime.unapply_apply t.clockTime)
+end
+
+/-- LT compares the underlying naive/TAI time. -/
+instance instLT : LT HClockTime where
   lt := InvImage NaiveClockTime.instLT.lt (fun t => t.clockTime.naive)
 
-/--
-LE compares the underlying naive/TAI time.
--/
-instance : LE HClockTime where
+/-- LE compares the underlying naive/TAI time. -/
+instance instLE : LE HClockTime where
   le := InvImage NaiveClockTime.instLE.le (fun t => t.clockTime.naive)
 
-theorem HClockTime.le_def (d₁ d₂ : HClockTime) : (d₁ <= d₂) = (d₁.clockTime.naive <= d₂.clockTime.naive) := rfl
-theorem HClockTime.lt_def (d₁ d₂ : HClockTime) : (d₁ < d₂) = (d₁.clockTime.naive < d₂.clockTime.naive) := rfl
+theorem HClockTime.le_def (d₁ d₂ : HClockTime) :
+  (d₁ <= d₂) = (d₁.clockTime.naive <= d₂.clockTime.naive)
+:= rfl
+theorem HClockTime.lt_def (d₁ d₂ : HClockTime) :
+  (d₁ < d₂) = (d₁.clockTime.naive < d₂.clockTime.naive)
+:= rfl
 
-instance instDecidableLTHClockTime (a b : HClockTime) : Decidable (a < b) := inferInstanceAs (Decidable (a.clockTime.naive < b.clockTime.naive))
-instance instDecidableLEHClockTime (a b : HClockTime) : Decidable (a <= b) := inferInstanceAs (Decidable (a.clockTime.naive <= b.clockTime.naive))
+instance instDecidableLT (a b : HClockTime) : Decidable (a < b) :=
+  inferInstanceAs (Decidable (a.clockTime.naive < b.clockTime.naive))
+instance instDecidableLE (a b : HClockTime) : Decidable (a <= b) :=
+  inferInstanceAs (Decidable (a.clockTime.naive <= b.clockTime.naive))
 
-/--
-HClockTime is only a Preorder since it does not respect antisymmetry.
-t₁ <= t₂ ∧ t₂ <= t₁ does not imply t₁ = t₂ since they may have different timezones.
+/-- HClockTime is only a Preorder since it does not respect antisymmetry:
+`t₁ <= t₂ ∧ t₂ <= t₁` does not imply `t₁ = t₂` since they may have different
+timezones.
 -/
-instance : Preorder HClockTime where
+instance instPreorder : Preorder HClockTime where
   le_refl a := le_refl a.clockTime.naive
   le_trans _a _b _c := Nat.le_trans
   lt_iff_le_not_le _a _b := Nat.lt_iff_le_not_le
-
-end HClockTimeStuff

--- a/Timelib/Util.lean
+++ b/Timelib/Util.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.Int.Defs
 import Mathlib.Data.Int.Lemmas
 import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Fin.Basic
 import Mathlib.Init.Order.Defs
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
@@ -9,6 +10,18 @@ import Mathlib.Init.Data.Int.Order
 import Mathlib.Logic.Equiv.Basic
 import Mathlib.Init.Data.Int.Order
 import Lean.Data.Json
+
+
+
+/-- #TODO
+- better name
+- documentation
+- possibly move to some helper namespace, *e.g.* `Util`
+-/
+protected def Fin.ofInt'' {n : ℕ} [Nonempty <| Fin n] : Int → Fin n
+| Int.ofNat a => Fin.ofNat' a Fin.size_positive'
+| Int.negSucc a => -(Fin.ofNat' a.succ Fin.size_positive')
+
 
 theorem h100 : ((146096 : Int) / 36524) * 100 = 400 := by decide
 theorem h4 : ((146096 : Int) % 36524) / 1461 * 4 = 0 := by decide


### PR DESCRIPTION
- moved `Fin.ofInt''` out of `NaivedClockTime.lean` and into `Util.lean`

`ClockTime` and `NaiveClockTime`:

- added `LinearOrder.compare_eq_compareOfLessAndEq` proofs
- manual `Ord` instance
- `eq_def` lemmas
- `eq_def'` lemma for `NaiveClockTime`

all `ClockTime/` files:

- improved presentation
- line wrap 80