### PR TITLE
Put everything in `Timelib` namespace

### DIFF
--- a/Timelib/Date/Basic.lean
+++ b/Timelib/Date/Basic.lean
@@ -5,6 +5,10 @@ import Timelib.Date.OrdinalDate
 import Timelib.Date.Ymd
 import Timelib.Date.Convert
 
+
+
+namespace Timelib
+
 def ScalarDate.firstOfTheMonth (year : Year) (m : Month) : ScalarDate :=
   Ymd.toScalarDate ⟨year, m, 1, le_refl _, Month.numDays_pos _ _⟩
 
@@ -44,7 +48,10 @@ def ScalarDate.kDayAfter (k : Nat) (d : ScalarDate) (h : k < 7 := by decide) : S
 If n > 0, the date of the nth k-day on or after the date.
 If n < 0, counts backwards, returning the nth k-day on or before the date.
 -/
-def ScalarDate.nthKDay (n : Int) (k : Nat) (d : ScalarDate) (hk : k < 7 := by decide) (hn : n ≠ 0 := by decide) : ScalarDate :=
+def ScalarDate.nthKDay
+  (n : Int) (k : Nat) (d : ScalarDate)
+  (hk : k < 7 := by decide) (_hn : n ≠ 0 := by decide)
+: ScalarDate :=
   if n > 0
   then ⟨7 * n + (d.kDayBefore k hk).day⟩
   else ⟨7 * n + (d.kDayAfter k hk).day⟩

--- a/Timelib/Date/Convert.lean
+++ b/Timelib/Date/Convert.lean
@@ -15,6 +15,10 @@ import Timelib.Util
 
 open Lean
 
+
+
+namespace Timelib
+
 theorem Year.lastDayFebruary_eq (y : Year) : y.lastDayFebruary = Month.february.numDays y + Year.lastDayJanuary := by
   by_cases h: y.isLeapYear <;> simp [h,  Month.numDays]
 

--- a/Timelib/Date/Lemmas/Basic.lean
+++ b/Timelib/Date/Lemmas/Basic.lean
@@ -3,7 +3,7 @@ import Mathlib.Init.Order.Defs
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Data.Int.Basic
-import Mathlib.Tactic.LibrarySearch
+-- import Mathlib.Tactic.LibrarySearch
 import Mathlib.Logic.Equiv.Basic
 import Mathlib.Init.Data.Int.Order
 import Timelib.Date.Year
@@ -14,6 +14,10 @@ import Timelib.Date.Ymd
 import Timelib.Date.Convert
 import Timelib.Util
 import Timelib.Date.Lemmas.YmdOrdinalEquiv
+
+
+
+namespace Timelib
 
 instance : Equiv Ymd OrdinalDate where
   toFun := Ymd.toOrdinalDate

--- a/Timelib/Date/Lemmas/YmdOrdinalEquiv.lean
+++ b/Timelib/Date/Lemmas/YmdOrdinalEquiv.lean
@@ -3,7 +3,7 @@ import Mathlib.Init.Order.Defs
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Data.Int.Basic
-import Mathlib.Tactic.LibrarySearch
+-- import Mathlib.Tactic.LibrarySearch
 import Mathlib.Logic.Equiv.Basic
 import Mathlib.Init.Data.Int.Order
 import Timelib.Date.Year
@@ -14,21 +14,24 @@ import Timelib.Date.Ymd
 import Timelib.Date.Convert
 import Timelib.Util
 
+
+
+namespace Timelib
+
 /--
 Proof that `Ymd` and `Ordinal` are Equivalent using their respective conversion functions
 `Ymd.toOrdinalDate` and `OrdinalDate.toYmd`
 -/
 
-theorem Ymd.is_january_month {ymd : Ymd} (h_is_month_day : (ymd.toOrdinalDate).isJanuaryDay) : ymd.month = Month.january := by
-  simp only [Ymd.toOrdinalDate]
-  by_cases hLeap : ymd.year.isLeapYear <;>
-    (simp_arith [hLeap, OrdinalDate.isJanuaryDay] at h_is_month_day
-     simp only [Ymd.toOrdinalDate] at h_is_month_day
-     simp only [hLeap]
-     split at h_is_month_day <;> (simp (config := { arith := true }) at *; try assumption)
-     case _ hM =>
-       simp_arith [hM] at h_is_month_day
-       exact False.elim ((show ¬0 >= 1 by decide) (h_is_month_day ▸ ymd.dayGe)))
+theorem Ymd.is_january_month {ymd : Ymd} :
+  (ymd.toOrdinalDate).isJanuaryDay → ymd.month = Month.january
+:= by
+  cases ymd ; case mk y m d h h' =>
+  simp [Ymd.toOrdinalDate]
+  split <;> simp_arith [h]
+  cases d with
+  | zero => contradiction
+  | succ _ => simp
 
 theorem Ymd.is_february_month {ymd : Ymd} (h_is_month_day : ymd.toOrdinalDate.isFebruaryDay) : ymd.month = Month.february := by
   simp only [Ymd.toOrdinalDate]
@@ -506,4 +509,3 @@ theorem Ymd.toOrdinalDate_left_inv (ymd : Ymd) : ymd.toOrdinalDate.toYmd = ymd :
                              simp [OrdinalDate.isDecemberDay, hLeap]
                              exact Nat.gt_of_not_le hNov
                            apply Ymd.eq_of_val_eq <;> simp [Ymd.toOrdinalDate, (Ymd.is_december_month h_is_month_day), hLeap, Nat.add_sub_cancel])
-

--- a/Timelib/Date/Month.lean
+++ b/Timelib/Date/Month.lean
@@ -11,10 +11,14 @@ import Timelib.Date.Year
 
 open Lean
 
-/-
-This ends up being easier to use than a Nat restricted to `1 <= n <= 12`,
-because we can define functions using the recursor without having to discharge
-the edge cases of 0 and n > 12
+
+
+namespace Timelib
+
+/-- Enumerates the month of a year.
+
+This ends up being easier to use than a `Nat` restricted to `1 ≤ n ≤ 12`, because we can define
+functions using the recursor without having to discharge the edge cases of `0` and `n > 12`.
 -/
 inductive Month
 | january

--- a/Timelib/Date/OrdinalDate.lean
+++ b/Timelib/Date/OrdinalDate.lean
@@ -10,6 +10,10 @@ import Timelib.Date.Year
 
 open Lean
 
+
+
+namespace Timelib
+
 structure OrdinalDate where
   year : Year
   day : Nat
@@ -29,7 +33,8 @@ instance : FromJson OrdinalDate where
     else Except.error s!"OrdinalDate day out of range: {day}"
 
 
-theorem OrdinalDate.eq_of_val_eq : ∀ {o₁ o₂ : OrdinalDate} (_ : o₁.year = o₂.year) (h_day : o₁.day = o₂.day), o₁ = o₂
+theorem OrdinalDate.eq_of_val_eq
+: ∀ {o₁ o₂ : OrdinalDate} (_ : o₁.year = o₂.year) (_h_day : o₁.day = o₂.day), o₁ = o₂
 | ⟨y₁, d₁, hGt₁, hLt₁⟩, ⟨y₂, d₂, hGt₂, hLt₂⟩, hy, hd => by simp [hy, hd]; exact
   { left := hy, right := hd }
 

--- a/Timelib/Date/ScalarDate.lean
+++ b/Timelib/Date/ScalarDate.lean
@@ -48,7 +48,7 @@ instance : LinearOrder ScalarDate where
 instance : Ord ScalarDate := ⟨fun d₁ d₂ => compareOfLessAndEq d₁ d₂⟩
 
 /-- Augments lean's `Int` namespace directly for convenience. -/
-def _root_.Int.rataDie (scalarScalarDate : Int) : Int :=
+protected def _root_.Int.rataDie (scalarScalarDate : Int) : Int :=
   Int.fmod scalarScalarDate 7
 
 @[reducible, simp]

--- a/Timelib/Date/ScalarDate.lean
+++ b/Timelib/Date/ScalarDate.lean
@@ -9,6 +9,10 @@ import Mathlib.Init.Data.Int.Order
 
 open Lean
 
+
+
+namespace Timelib
+
 structure ScalarDate where
   day : Int
 deriving Repr, ToJson, FromJson
@@ -43,7 +47,9 @@ instance : LinearOrder ScalarDate where
 
 instance : Ord ScalarDate := ⟨fun d₁ d₂ => compareOfLessAndEq d₁ d₂⟩
 
-def Int.rataDie (scalarScalarDate : Int) : Int := Int.fmod scalarScalarDate 7
+/-- Augments lean's `Int` namespace directly for convenience. -/
+def _root_.Int.rataDie (scalarScalarDate : Int) : Int :=
+  Int.fmod scalarScalarDate 7
 
 @[reducible, simp]
 abbrev ScalarDate.dayOfWeek (d : ScalarDate) : Int := d.day.rataDie

--- a/Timelib/Date/Year.lean
+++ b/Timelib/Date/Year.lean
@@ -11,6 +11,10 @@ import Mathlib.Init.Data.Int.Order
 
 open Lean
 
+
+
+namespace Timelib
+
 /--
 A year in the proleptic gregorian calendar
 -/
@@ -33,10 +37,10 @@ theorem Year.lt_def {y₁ y₂ : Year} : (y₁ < y₂) = (y₁.val < y₂.val) :
 instance instDecidableLEYear (y₁ y₂ : Year) : Decidable (y₁ <= y₂) := inferInstanceAs (Decidable (y₁.val <= y₂.val))
 instance instDecidableLTYear (y₁ y₂ : Year) : Decidable (y₁ < y₂) := inferInstanceAs (Decidable (y₁.val < y₂.val))
 
-theorem Year.val_eq_of_eq : ∀ {y₁ y₂ : Year} (h : y₁ = y₂), y₁.val = y₂.val
+theorem Year.val_eq_of_eq : ∀ {y₁ y₂ : Year} (_h : y₁ = y₂), y₁.val = y₂.val
 | ⟨_⟩, _, rfl => rfl
 
-theorem Year.eq_of_val_eq : ∀ {y₁ y₂ : Year} (h : y₁.val = y₂.val), y₁ = y₂
+theorem Year.eq_of_val_eq : ∀ {y₁ y₂ : Year} (_h : y₁.val = y₂.val), y₁ = y₂
 | ⟨_⟩, _, rfl => rfl
 
 instance : LinearOrder Year where
@@ -73,6 +77,10 @@ leap years, but the years 1600 and 2000 are."
 -/
 @[reducible]
 abbrev Year.isLeapYear (y : Year) : Prop := (y.val % 4 = 0 ∧ y.val % 100 ≠ 0) ∨ (y.val % 400 = 0)
+
+instance Year.instDecidable_isLeapYear (y : Year) : Decidable y.isLeapYear := by
+  simp [isLeapYear]
+  exact inferInstance
 
 @[reducible] abbrev Year.numDaysInGregorianYear (y : Year) : Nat := 365 + (if y.isLeapYear then 1 else 0)
 

--- a/Timelib/Date/Ymd.lean
+++ b/Timelib/Date/Ymd.lean
@@ -11,6 +11,10 @@ import Timelib.Date.Month
 
 open Lean
 
+
+
+namespace Timelib
+
 structure Ymd where
   year : Year
   month : Month

--- a/Timelib/DateTime/DateTime.lean
+++ b/Timelib/DateTime/DateTime.lean
@@ -4,6 +4,8 @@ import Timelib.Util
 import Timelib.DateTime.TimeZone
 import Timelib.DateTime.LeapSeconds
 
+
+
 namespace Timelib
 
 structure DateTime (precision : Int) (L : LeapSeconds) (Z : TimeZone)

--- a/Timelib/DateTime/LeapSeconds.lean
+++ b/Timelib/DateTime/LeapSeconds.lean
@@ -1,7 +1,8 @@
-
 import Timelib.Util
 import Timelib.DateTime.NaiveDateTime
 import Timelib.Duration.SignedDuration
+
+
 
 namespace Timelib
 

--- a/Timelib/DateTime/NaiveDateTime.lean
+++ b/Timelib/DateTime/NaiveDateTime.lean
@@ -1,4 +1,3 @@
-
 import Timelib.Util
 import Timelib.Date.ScalarDate
 import Timelib.Date.Convert
@@ -8,17 +7,19 @@ import Mathlib.Order.WithBot
 import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Order.Sub.WithTop
 import Mathlib.Algebra.Order.Ring.WithTop
+
+
+
 namespace Timelib
 
 /--
-If nonnegative, the number of nanoseconds since the epoch (midnight of 0001/Jan/01)
-If negative, the number of nanoseconds until the epoch (midnight of 0001/Jan/01)
+If nonnegative, the number of nanoseconds since the epoch (midnight of 0001/Jan/01); if negative,
+the number of nanoseconds until the epoch (midnight of 0001/Jan/01).
 
-A `NaiveDateTime pow` represents a date and time in the appropriate SI unit which has no knowledge of
-leap seconds or time zones.
+A `NaiveDateTime pow` represents a date and time in the appropriate SI unit which has no knowledge
+of leap seconds or time zones.
 
-`DateTime` elements can only be indexed by SI exponents less than
-or equal to zero.
+`DateTime` elements can only be indexed by SI exponents less than or equal to zero.
 -/
 structure NaiveDateTime (p : Int) extends SignedDuration p where
   isLe : p <= 0
@@ -28,11 +29,11 @@ namespace NaiveDateTime
 variable {siPow : Int}
 
 /-
-Using `Int.fdiv`, because we have a positive denominator (the number of seconds in a day)
-and we want to round down if `dt.val` is negative, up if it's nonnegative.
+Using `Int.fdiv`, because we have a positive denominator (the number of seconds in a day) and we
+want to round down if `dt.val` is negative, up if it's nonnegative.
 
-Equivalently, you can round toward zero and only add `1` if the
-quotient is greater than of equal to zero.
+Equivalently, you can round toward zero and only add `1` if the quotient is greater than of equal to
+zero.
 -/
 def toScalarDate (dt : NaiveDateTime siPow) : ScalarDate :=
   let oneDay := SignedDuration.Constants.oneDayDuration dt.isLe
@@ -57,9 +58,8 @@ instance instInhabited {p : Int} {isLe : p <= 0} : Inhabited (NaiveDateTime p) w
 def dayOfWeek (dt : NaiveDateTime siPow) : Int :=
   dt.toScalarDate.dayOfWeek
 
-/-- The `DateTime` as of midnight (00:00:00 uninterpreted) on the ymd. We
-subtract one to account for the fact that `Date` is one day ahead of the
-zero-based `NaiveDateTime`.
+/-- The `DateTime` as of midnight (00:00:00 uninterpreted) on the ymd. We subtract one to account
+for the fact that `Date` is one day ahead of the zero-based `NaiveDateTime`.
 -/
 def fromYmd
   {siPow : Int}
@@ -114,7 +114,9 @@ instance instEquivIntSelf {siPow : Int} {isLe : siPow <= 0} : Equiv Int (NaiveDa
   left_inv := by simp only [Function.LeftInverse, forall_const]
   right_inv := by simp only [Function.RightInverse, Function.LeftInverse, implies_true]
 
-instance instEquivSignedDurationSelf {siPow : Int} {isLe : siPow <= 0} : Equiv (SignedDuration siPow) (NaiveDateTime siPow) where
+instance instEquivSignedDurationSelf {siPow : Int} {isLe : siPow <= 0} :
+  Equiv (SignedDuration siPow) (NaiveDateTime siPow)
+where
   toFun := fun dur => NaiveDateTime.mk dur.val isLe
   invFun := fun d => d.toSignedDuration
   left_inv _ := rfl

--- a/Timelib/DateTime/TimeZone.lean
+++ b/Timelib/DateTime/TimeZone.lean
@@ -2,6 +2,8 @@ import Timelib.Util
 import Timelib.DateTime.NaiveDateTime
 import Timelib.Duration.SignedDuration
 
+
+
 namespace Timelib
 
 structure TimeZone where

--- a/Timelib/SignedInt.lean
+++ b/Timelib/SignedInt.lean
@@ -1,3 +1,5 @@
+namespace Timelib
+
 /-
 A two's complement representation of signed integers, implemented as a struct pulling back
 on the prelude's signed integer types. For example, the relationship between
@@ -422,15 +424,15 @@ instance (a b : Int64) : Decidable (a < b) :=
 /-
 sameSign a b ∧ differentSign a out
 -/
-def Int64.wrappingAdd (a b : Int64) : (Bool × Int64) := 
+def Int64.wrappingAdd (a b : Int64) : (Bool × Int64) :=
   let sum := a + b
   let oob :=
-    if a.isPositive 
-    then 
+    if a.isPositive
+    then
       if b.isPositive
       then sum.isNegative
       else false
-    else 
+    else
       if b.isNegative
       then sum.isPositive
       else false

--- a/Timelib/Util.lean
+++ b/Timelib/Util.lean
@@ -13,10 +13,11 @@ import Lean.Data.Json
 
 
 
+namespace Timelib
+
 /-- #TODO
 - better name
 - documentation
-- possibly move to some helper namespace, *e.g.* `Util`
 -/
 protected def Fin.ofInt'' {n : ℕ} [Nonempty <| Fin n] : Int → Fin n
 | Int.ofNat a => Fin.ofNat' a Fin.size_positive'
@@ -37,48 +38,64 @@ theorem pos4 : (0 : Int) < 4 := by decide
 theorem pos100 : (0 : Int) < 100 := by decide
 theorem pos400 : (0 : Int) < 400 := by decide
 
+
+
+/-! `Nat` lemmas. -/
+namespace Nat
+
 theorem not_lt_and_gt {day lo hi : Nat} (day_lt_lo : (day < lo)) (lo_lt_hi : lo < hi) : ¬hi < day :=
   fun hi_lt_day => lt_asymm (lt_trans lo_lt_hi hi_lt_day) day_lt_lo
 
-theorem not_le_and_gt {day lo hi : Nat} (day_le_lo : (day <= lo)) (lo_lt_hi : lo < hi) : ¬hi < day :=
+theorem not_le_and_gt {day lo hi : Nat} (day_le_lo : (day ≤ lo)) (lo_lt_hi : lo < hi) : ¬hi < day :=
   fun hi_lt_day => lt_asymm (lt_of_lt_of_le hi_lt_day day_le_lo) lo_lt_hi
 
-theorem not_le_and_ge_of_lt {day lo hi : Nat} (h0 : day <= lo) (h1 : lo < hi) : ¬hi <= day :=
+theorem not_le_and_ge_of_lt {day lo hi : Nat} (h0 : day ≤ lo) (h1 : lo < hi) : ¬hi ≤ day :=
   fun hi_le_day => absurd hi_le_day (not_le_of_gt <| lt_of_le_of_lt h0 h1)
 
-theorem Nat.lt_of_succ_le_sub {m n l : Nat} (h : l.succ <= m - n) : n < m :=
-  Nat.lt_of_sub_eq_succ (Nat.succ_pred (not_eq_zero_of_lt h)).symm
+theorem lt_of_succ_le_sub {m n l : Nat} (h : l.succ ≤ m - n) : n < m :=
+  Nat.lt_of_sub_eq_succ (Nat.succ_pred (Nat.not_eq_zero_of_lt h)).symm
 
-theorem Nat.lt_of_succ_le_sub' {m n l : Nat} (h0 : 0 < l) (h : l <= m - n) : n < m := by
-  have h0 : l.pred.succ = l := Nat.succ_pred (not_eq_zero_of_lt h0)
+theorem lt_of_succ_le_sub' {m n l : Nat} (h0 : 0 < l) (h : l ≤ m - n) : n < m := by
+  have h0 : l.pred.succ = l := Nat.succ_pred (Nat.not_eq_zero_of_lt h0)
   rw [<- h0] at h
   exact Nat.lt_of_succ_le_sub h
 
-theorem Int.of_nat_nonneg (n : ℕ) : 0 ≤ Int.ofNat n := by
+theorem div_le_div_right' {n m : Nat} (h : n ≤ m) {k : Nat} :
+  n / k ≤ m / k
+:= Nat.div_le_div_right h
+
+end Nat
+
+
+
+/-! `Int` lemmas. -/
+namespace Int
+
+theorem of_nat_nonneg (n : ℕ) : 0 ≤ Int.ofNat n := by
   simp
 
--- theorem Int.mod_nonneg (a : ℤ) {b : ℤ} : b ≠ 0 → 0 ≤ a % b := sorry
+-- theorem mod_nonneg (a : ℤ) {b : ℤ} : b ≠ 0 → 0 ≤ a % b := sorry
 
--- theorem Int.mod_lt_of_pos (a : ℤ) {b : ℤ} (H : 0 < b) : a % b < b := sorry
+-- theorem mod_lt_of_pos (a : ℤ) {b : ℤ} (H : 0 < b) : a % b < b := sorry
 
--- @[simp] theorem Int.zero_mod (b : ℤ) : 0 % b = 0 := sorry
+-- @[simp] theorem zero_mod (b : ℤ) : 0 % b = 0 := sorry
 
--- theorem Int.le_sub_one_iff {a b : ℤ} : a ≤ b - 1 ↔ a < b := sorry
+-- theorem le_sub_one_iff {a b : ℤ} : a ≤ b - 1 ↔ a < b := sorry
 
--- theorem Int.lt_add_one_iff {a b : ℤ} : a < b + 1 ↔ a ≤ b := sorry
+-- theorem lt_add_one_iff {a b : ℤ} : a < b + 1 ↔ a ≤ b := sorry
 
 --@[simp]
---theorem Int.mul_div_cancel (a : ℤ) {b : ℤ} (H : b ≠ 0) : a * b / b = a := sorry
+--theorem mul_div_cancel (a : ℤ) {b : ℤ} (H : b ≠ 0) : a * b / b = a := sorry
 
 /-- # TODO
 
 - just an abbrev of `Int.ediv_add_emod'`;
 - not used anywhere.
 -/
-abbrev int.div_add_mod' : ∀ (m k : ℤ), m / k * k + m % k = m :=
+abbrev div_add_mod' : ∀ (m k : ℤ), m / k * k + m % k = m :=
   Int.ediv_add_emod'
 
-theorem Int.div_eq_zero_of_lt' {a b : ℤ} (H1 : 0 ≤ a) (H2 : a < b) : a / b = 0
+theorem div_eq_zero_of_lt' {a b : ℤ} (H1 : 0 ≤ a) (H2 : a < b) : a / b = 0
 := by
   rw [←div_eq_ediv]
   apply Int.div_eq_zero_of_lt H1 H2
@@ -91,9 +108,9 @@ where
       apply Int.lt_of_le_of_lt H1 H2
 
 --@[simp]
---theorem Int.zero_div : ∀ (d : Int), 0 / d = 0 := sorry
+--theorem zero_div : ∀ (d : Int), 0 / d = 0 := sorry
 
-theorem Int.fmod_nonneg_of_pos_mod : ∀ (x : Int) {m : Int}, (h : 0 < m) → 0 <= x.fmod m
+theorem fmod_nonneg_of_pos_mod : ∀ (x : Int) {m : Int}, (h : 0 < m) → 0 ≤ x.fmod m
 | _, Int.negSucc _, hm => by cases hm; done
 | _, Int.ofNat 0, hm => by cases hm; done
 | Int.ofNat 0, Int.ofNat (_m+1), _hm => by simp [Int.fmod]
@@ -101,10 +118,10 @@ theorem Int.fmod_nonneg_of_pos_mod : ∀ (x : Int) {m : Int}, (h : 0 < m) → 0 
   simp only [Int.fmod]
   apply Int.ofNat_zero_le
 | Int.negSucc xNat, Int.ofNat (mNat+1), hm => by
-  refine' fmod_nonneg' _ hm
+  refine' Int.fmod_nonneg' _ hm
 
 @[simp]
-theorem Int.fdiv_pos_eq_div : ∀ {a b : Int}, 0 <= a → 0 <= b → Int.fdiv a b = a / b
+theorem fdiv_pos_eq_div : ∀ {a b : Int}, 0 ≤ a → 0 ≤ b → Int.fdiv a b = a / b
 | .ofNat 0, .ofNat b_n, _ha, _hb => by simp [Int.fdiv]
 | .negSucc _, _, ha, _hb => by cases ha
 | _, .negSucc _, _ha, hb => by cases hb
@@ -112,7 +129,7 @@ theorem Int.fdiv_pos_eq_div : ∀ {a b : Int}, 0 <= a → 0 <= b → Int.fdiv a 
   simp [Int.fdiv]
 
 @[simp]
-theorem Int.fmod_pos_eq_mod : ∀ {a b : Int}, 0 <= a → 0 <= b → a.fmod b = a % b
+theorem fmod_pos_eq_mod : ∀ {a b : Int}, 0 ≤ a → 0 ≤ b → a.fmod b = a % b
 | .ofNat 0, .ofNat b_n, _ha, _hb => by simp [Int.fmod]
 | .negSucc _, _, ha, _hb => by cases ha
 | _, .negSucc _, _ha, hb => by cases hb
@@ -120,30 +137,30 @@ theorem Int.fmod_pos_eq_mod : ∀ {a b : Int}, 0 <= a → 0 <= b → a.fmod b = 
   simp [Int.fmod]
 
 @[simp]
-theorem Int.fmod_fmod_eq (a : Int) {m₀ m₁ : Int} (h : 0 < m₀) (h' : 0 <= m₁) :
+theorem fmod_fmod_eq (a : Int) {m₀ m₁ : Int} (h : 0 < m₀) (h' : 0 ≤ m₁) :
   (a.fmod m₀).fmod m₁ = (a.fmod m₀) % m₁ :=
     @Int.fmod_pos_eq_mod (a.fmod m₀) m₁ (Int.fmod_nonneg_of_pos_mod a h) h'
 
 @[simp]
-theorem Int.fdiv_fmod_eq_fmod_div (a : Int) {m d : Int} (h : 0 < m) (h' : 0 < d) :
+theorem fdiv_fmod_eq_fmod_div (a : Int) {m d : Int} (h : 0 < m) (h' : 0 < d) :
   (a.fmod m).fdiv d = (a.fmod m) / d :=
   @fdiv_pos_eq_div (a.fmod m) d (Int.fmod_nonneg_of_pos_mod _ h) (le_of_lt h')
 
 @[simp]
-theorem Int.fdiv_mod_eq_mod_div (a : Int) {m d : Int} (h : 0 < m) (h' : 0 < d) :
+theorem fdiv_mod_eq_mod_div (a : Int) {m d : Int} (h : 0 < m) (h' : 0 < d) :
   (a % m).fdiv d = (a % m) / d :=
-  @fdiv_pos_eq_div (a % m) d (emod_nonneg a <| Int.ne_of_gt h) (le_of_lt h')
+  @fdiv_pos_eq_div (a % m) d (Int.emod_nonneg a <| Int.ne_of_gt h) (le_of_lt h')
 
 
 @[simp]
-theorem Int.fmodmod (a : Int) {m₀ m₁ m₂ : Int} (_h0 : 0 < m₀) (h1 : 0 < m₁) (h2 : 0 < m₂) :
+theorem fmodmod (a : Int) {m₀ m₁ m₂ : Int} (_h0 : 0 < m₀) (h1 : 0 < m₁) (h2 : 0 < m₂) :
   ((a.fmod m₀) % m₁).fmod m₂ = (a.fmod m₀) % m₁ % m₂ :=
-  @Int.fmod_pos_eq_mod (a.fmod m₀ % m₁) m₂ (emod_nonneg _ (ne_of_gt h1)) (le_of_lt h2)
+  @Int.fmod_pos_eq_mod (a.fmod m₀ % m₁) m₂ (Int.emod_nonneg _ (ne_of_gt h1)) (le_of_lt h2)
 
 @[simp]
-theorem Int.mod_fmod_eq_mod_mod {a m₀ m₁ : Int} (h0 : 0 < m₀) (h1 : 0 <= m₁) :
+theorem mod_fmod_eq_mod_mod {a m₀ m₁ : Int} (h0 : 0 < m₀) (h1 : 0 ≤ m₁) :
   (a % m₀).fmod m₁ = (a % m₀) % m₁ :=
-    Int.fmod_pos_eq_mod (emod_nonneg _ (ne_of_lt h0).symm) h1
+    Int.fmod_pos_eq_mod (Int.emod_nonneg _ (ne_of_lt h0).symm) h1
 
 theorem fdiv_neg_eq
   {a_n b_n : Nat}
@@ -154,13 +171,13 @@ theorem fdiv_neg_eq
   rw [h_b]
   done
 
---theorem Int.div_add_mod (a b : ℤ) : b * (a / b) + a % b = a := sorry
+--theorem div_add_mod (a b : ℤ) : b * (a / b) + a % b = a := sorry
 
-theorem Int.fmod_lt : ∀ (x : Int) {m : Int}, (h : 0 < m) → x.fmod m < m
+theorem fmod_lt : ∀ (x : Int) {m : Int}, (h : 0 < m) → x.fmod m < m
 | Int.ofNat 0, Int.ofNat _mn, hm => hm
 | Int.ofNat (xn+1), Int.ofNat mn, hm => by
   simp [Int.fmod]
-  exact emod_lt_of_pos (↑xn + 1) hm
+  exact Int.emod_lt_of_pos (↑xn + 1) hm
 
   --split
   --next => exact hm
@@ -173,12 +190,12 @@ theorem Int.fmod_lt : ∀ (x : Int) {m : Int}, (h : 0 < m) → x.fmod m < m
   --next f g => cases f
 | Int.negSucc x, Int.ofNat m, hm => by
   simp [Int.fmod, Int.subNatNat]
-  have hh : (x % m).succ <= m := @Nat.mod_lt x m (Int.ofNat_lt.mp hm)
+  have hh : (x % m).succ ≤ m := @Nat.mod_lt x m (Int.ofNat_lt.mp hm)
   simp [Nat.sub_eq_zero_of_le hh]
   refine' Nat.sub_lt_of_pos_le (Nat.succ_pos (x % m)) hh
 | _, Int.negSucc _, hm => by cases hm; done
 
-theorem ne_neg_succ_of_zero_le {a : Int} {b : Nat} (h : 0 <= a) : ¬(a = Int.negSucc b) := fun h' => by
+theorem ne_neg_succ_of_zero_le {a : Int} {b : Nat} (h : 0 ≤ a) : ¬(a = Int.negSucc b) := fun h' => by
   cases a with
   | ofNat _ => cases h'
   | negSucc _ => cases h
@@ -188,15 +205,15 @@ theorem ne_of_nat_of_lt_zero {a : Int} {b : Nat} (h : a < 0) : ¬(a = Int.ofNat 
   | ofNat _ => cases h
   | negSucc _ => cases h'
 
-theorem Int.add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
+theorem add_mul_div_left (a : ℤ) {b : ℤ} (c : ℤ) (H : b ≠ 0) :
   (a + b * c) / b = a / b + c
 := Int.add_mul_ediv_left a c H
 
-theorem Int.add_mul_div_right (a b : Int) {c : Int} (H : c ≠ 0) :
+theorem add_mul_div_right (a b : Int) {c : Int} (H : c ≠ 0) :
   (a + b * c) / c = a / c + b
 := Int.add_mul_ediv_right a b H
 
-theorem div_eq_zero_of_lt : ∀ {a b : Int}, 0 <= a → 0 <= b → a < b → a / b = 0
+theorem div_eq_zero_of_lt : ∀ {a b : Int}, 0 ≤ a → 0 ≤ b → a < b → a / b = 0
 | .ofNat a, .ofNat b, ha, hb, hlt => by
   have hx : a < b := by exact (@Int.ofNat_le (a+1) b).mp hlt
   have hy := Nat.div_eq_of_lt hx
@@ -206,38 +223,36 @@ theorem div_eq_zero_of_lt : ∀ {a b : Int}, 0 <= a → 0 <= b → a < b → a /
 | .negSucc a, .ofNat b, ha, _hb, _hlt => by cases ha
 | .negSucc _, .negSucc _, ha, _hb, _hlt => by cases ha
 
-theorem neither_lem (a b c : Int) (h0 : 0 <= (a * b)) (h1 : 0 <= c) (hb : 0 < b) (h : c < b) : ((a * b) + c).fdiv b = a := by
-  have hsum : 0 <= (a * b + c) := Int.add_nonneg h0 h1
+theorem neither_lem (a b c : Int) (h0 : 0 ≤ (a * b)) (h1 : 0 ≤ c) (hb : 0 < b) (h : c < b) : ((a * b) + c).fdiv b = a := by
+  have hsum : 0 ≤ (a * b + c) := Int.add_nonneg h0 h1
   simp [Int.fdiv_pos_eq_div hsum (le_of_lt hb)]
   have hdiv : (a * b + c) / b = a := by
     have hdiv' := Int.add_mul_div_right c a (ne_of_lt hb).symm
     rwa [add_comm, div_eq_zero_of_lt h1 (le_of_lt hb) h, zero_add] at hdiv'
   exact hdiv
 
-theorem Nat.div_le_div_right' {n m : Nat} (h : n ≤ m) {k : Nat} :
-  n / k ≤ m / k
-:= Nat.div_le_div_right h
-
-theorem Int.not_of_nat_le_neg_succ (a b : Nat) : ¬(Int.ofNat a <= Int.negSucc b) := fun h => by
+theorem not_of_nat_le_neg_succ (a b : Nat) : ¬(Int.ofNat a ≤ Int.negSucc b) := fun h => by
   exact absurd (lt_of_le_of_lt h (Int.negSucc_lt_zero b)) (not_lt_of_ge (Int.ofNat_zero_le a))
 
-theorem Int.neg_succ_monotone {x y : Nat} (h : x >= y) : Int.negSucc x <= Int.negSucc y := by
+theorem neg_succ_monotone {x y : Nat} (h : x ≥ y) : Int.negSucc x ≤ Int.negSucc y := by
   simp [Int.le_def, Int.nonneg_def, Int.sub_eq_add_neg]
-  have h0 : - negSucc x = (x.succ) := PLift.down_up (- negSucc x)
+  have h0 : - Int.negSucc x = (x.succ) := PLift.down_up (- Int.negSucc x)
   simp [h0]
   refine Exists.intro ((x + 1) - (y + 1)) ?h
-  have h1 : negSucc y + ((↑x) +1) = subNatNat (x+1) (Nat.succ y) := Int.negSucc_add_ofNat y (x + 1)
+  have h1 : Int.negSucc y + ((↑x) +1) = Int.subNatNat (x+1) (Nat.succ y) :=
+    Int.negSucc_add_ofNat y (x + 1)
   simp only [h1]
   apply Int.subNatNat_of_le
   apply Nat.succ_le_succ
   exact h
 
-theorem Int.neg_succ_monotone_rev {x y : Nat} : Int.negSucc x <= Int.negSucc y → x >= y := by
+theorem neg_succ_monotone_rev {x y : Nat} : Int.negSucc x ≤ Int.negSucc y → x ≥ y := by
   simp [Int.le_def, Int.nonneg_def, Int.sub_eq_add_neg]
-  have h0 : - negSucc x = (x.succ) := PLift.down_up (- negSucc x)
+  have h0 : - Int.negSucc x = (x.succ) := PLift.down_up (- Int.negSucc x)
   simp [h0]
   intro sum
-  have h1 : negSucc y + ((↑x) +1) = subNatNat (x+1) (Nat.succ y) := Int.negSucc_add_ofNat y (x + 1)
+  have h1 : Int.negSucc y + ((↑x) +1) = Int.subNatNat (x+1) (Nat.succ y) :=
+    Int.negSucc_add_ofNat y (x + 1)
   simp [h1]
   intro h2
   apply le_of_not_gt
@@ -246,15 +261,15 @@ theorem Int.neg_succ_monotone_rev {x y : Nat} : Int.negSucc x <= Int.negSucc y �
   rw [h2] at h4
   cases h4
 
-theorem Int.fdiv_le_div_right {n₁ n₂ de : Int} (h : n₁ <= n₂) (hde : 0 <= de) :
-  n₁.fdiv de <= n₂.fdiv de
+theorem fdiv_le_div_right {n₁ n₂ de : Int} (h : n₁ ≤ n₂) (hde : 0 ≤ de) :
+  n₁.fdiv de ≤ n₂.fdiv de
 := by
   simp [Int.fdiv]
   split
   next =>
     split
     · simp
-    · exact ediv_nonneg h hde
+    · exact Int.ediv_nonneg h hde
     · cases hde
     · exact le_refl _
     · cases hde
@@ -291,30 +306,30 @@ theorem Int.fdiv_le_div_right {n₁ n₂ de : Int} (h : n₁ <= n₂) (hde : 0 <
   next=> cases hde
 
 
-theorem Int.add_right_nonneg {x n : Int} (h : 0 <= x) (h' : 0 <= n) : 0 <= x + n :=
+theorem add_right_nonneg {x n : Int} (h : 0 ≤ x) (h' : 0 ≤ n) : 0 ≤ x + n :=
   Int.add_nonneg h h'
 
-theorem Int.toNat_le_of_le_of_nonneg : ∀ {x : Int} {y : Nat}, 0 <= x → x <= y → x.toNat <= y
+theorem toNat_le_of_le_of_nonneg : ∀ {x : Int} {y : Nat}, 0 ≤ x → x ≤ y → x.toNat ≤ y
 | .ofNat n, y, _h1, h2 => by
   simp at h2
   simp [Int.toNat, h2]
 | .negSucc _, _, h1, _h2 => by cases h1
 
-theorem Int.div_le_of_le_mul : ∀ {a b c : ℤ}, 0 < c → a ≤ b * c → a / c ≤ b :=
+theorem div_le_of_le_mul : ∀ {a b c : ℤ}, 0 < c → a ≤ b * c → a / c ≤ b :=
   Int.ediv_le_of_le_mul
-theorem Int.div_lt_of_lt_mul {a b c : ℤ} (H : 0 < c) (H' : a < b * c) : a / c < b :=
+theorem div_lt_of_lt_mul {a b c : ℤ} (H : 0 < c) (H' : a < b * c) : a / c < b :=
   Int.ediv_lt_iff_lt_mul H |>.mpr H'
-theorem Int.mul_lt_of_lt_div : ∀ {a b c : ℤ}, 0 < c → a < b / c → a * c < b :=
+theorem mul_lt_of_lt_div : ∀ {a b c : ℤ}, 0 < c → a < b / c → a * c < b :=
   Int.mul_lt_of_lt_ediv
-theorem Int.lt_mul_of_div_lt {a b c : ℤ} (H : 0 < c) (H' : a / c < b) : a < b * c :=
+theorem lt_mul_of_div_lt {a b c : ℤ} (H : 0 < c) (H' : a / c < b) : a < b * c :=
   Int.ediv_lt_iff_lt_mul H |>.mp H'
 
-theorem Int.mul_le_of_le_div {a b c : Int} (H1 : 0 < c) (H2 : a ≤ b / c) : a * c ≤ b :=
+theorem mul_le_of_le_div {a b c : Int} (H1 : 0 < c) (H2 : a ≤ b / c) : a * c ≤ b :=
   Int.le_ediv_iff_mul_le H1 |>.mp H2
 
-theorem Int.mul_le_of_le_fdiv
-  {n d q : Int} (hn : 0 <= n) (hd : 0 < d) (_hq : 0 < q) (h : n.fdiv d = q)
-: q * d <= n := by
+theorem mul_le_of_le_fdiv
+  {n d q : Int} (hn : 0 ≤ n) (hd : 0 < d) (_hq : 0 < q) (h : n.fdiv d = q)
+: q * d ≤ n := by
   simp [fdiv_pos_eq_div hn (le_of_lt hd)] at h
   exact Int.mul_le_of_le_div hd (le_of_eq h.symm)
 
@@ -322,43 +337,47 @@ theorem Int.mul_le_of_le_fdiv
 
 Alias for `Int.add_mod_self`, which is already `@[simp]`.
 -/
-@[simp] theorem Int.add_mod_self {a b : Int} : (a + b) % b = a % b :=
+@[simp]
+theorem add_mod_self {a b : Int} : (a + b) % b = a % b :=
   Int.add_emod_self
 
---@[simp] theorem Int.mul_mod_left (a b : Int) : a * b % b = 0 := sorry
+--@[simp] theorem mul_mod_left (a b : Int) : a * b % b = 0 := sorry
 
-@[simp] theorem Int.mul_mod (a b n : Int) : a * b % n = a % n * (b % n) % n :=
+@[simp]
+theorem mul_mod (a b n : Int) : a * b % n = a % n * (b % n) % n :=
   Int.mul_emod a b n
 
 /-- # TODO
 
 Alias for `Int.add_mul_emod_self`, which is already `@[simp]`.
 -/
-@[simp] theorem Int.add_mul_mod_self {a b c : ℤ} : (a + b * c) % c = a % c :=
+@[simp]
+theorem add_mul_mod_self {a b c : ℤ} : (a + b * c) % c = a % c :=
   Int.add_mul_emod_self
 
---@[simp] theorem Int.mod_eq_zero_lemma (a b c m : Int) : (((a * m) + (b * m)) + c * m) % m = 0 := by simp
+--@[simp] theorem mod_eq_zero_lemma (a b c m : Int) : (((a * m) + (b * m)) + c * m) % m = 0 := by simp
 
-@[simp] theorem Int.mod_eq_zero_lemma' (a b c m : Int) : (((a * m) + (b * m)) + c) % m = c % m := by
+@[simp]
+theorem mod_eq_zero_lemma' (a b c m : Int) : (((a * m) + (b * m)) + c) % m = c % m := by
   simp [(Int.add_mul a b m).symm, add_comm ((a + b) * m) c]
 
---@[simp] theorem Int.mod_eq_of_lt {a b : ℤ} (H1 : 0 ≤ a) (H2 : a < b) : a % b = a := sorry
+--@[simp] theorem mod_eq_of_lt {a b : ℤ} (H1 : 0 ≤ a) (H2 : a < b) : a % b = a := sorry
 
---theorem Int.div_nonneg {a b : ℤ} (Ha : 0 ≤ a) (Hb : 0 ≤ b) : 0 ≤ a / b := sorry
+--theorem div_nonneg {a b : ℤ} (Ha : 0 ≤ a) (Hb : 0 ≤ b) : 0 ≤ a / b := sorry
 
-theorem Int.add_pos_ne_zero_of_nonneg {a b : Int} (h : 0 <= a) (h' : 0 < b) : a + b ≠ 0 := fun hf => by
-  have hle : a <= a + b := Int.le_add_of_nonneg_right (le_of_lt h')
+theorem add_pos_ne_zero_of_nonneg {a b : Int} (h : 0 ≤ a) (h' : 0 < b) : a + b ≠ 0 := fun hf => by
+  have hle : a ≤ a + b := Int.le_add_of_nonneg_right (le_of_lt h')
   rw [le_antisymm (hf ▸ hle) h] at hf
   simp at hf
   rw [hf] at h'
   exact False.elim $ lt_irrefl _ h'
 
-theorem Int.div_mod_unique {a b r q : ℤ} (h : 0 < b) :
+theorem div_mod_unique {a b r q : ℤ} (h : 0 < b) :
   a / b = q ∧ a % b = r ↔ r + b * q = a ∧ 0 ≤ r ∧ r < b
 :=
   Int.ediv_emod_unique h
 
-theorem Int.div_pigeonhole {x lower c : Int} (_hx : 0 <= x) (_hlower : 0 < lower) (hc : 0 < c) : c * lower < x → x < c * (lower + 1) → (x / c) = lower := fun h1 h2 => by
+theorem div_pigeonhole {x lower c : Int} (_hx : 0 ≤ x) (_hlower : 0 < lower) (hc : 0 < c) : c * lower < x → x < c * (lower + 1) → (x / c) = lower := fun h1 h2 => by
   rw [mul_comm] at h2
   have div_lt_plus_one := Int.div_lt_of_lt_mul hc h2
   apply by_contradiction
@@ -368,7 +387,7 @@ theorem Int.div_pigeonhole {x lower c : Int} (_hx : 0 <= x) (_hlower : 0 < lower
     rw [mul_comm] at h1
     exact False.elim ((lt_asymm h1) (Int.lt_mul_of_div_lt hc hl))
   | inr hr =>
-    have h_div_le : (x / c) <= lower := Int.le_of_add_le_add_right (Int.div_lt_of_lt_mul hc h2)
+    have h_div_le : (x / c) ≤ lower := Int.le_of_add_le_add_right (Int.div_lt_of_lt_mul hc h2)
     cases lt_or_eq_of_le h_div_le with
     | inl hlx =>
       rw [mul_comm] at h1
@@ -376,8 +395,8 @@ theorem Int.div_pigeonhole {x lower c : Int} (_hx : 0 <= x) (_hlower : 0 < lower
     | inr hrx => exact False.elim (hne hrx)
 
 @[simp]
-theorem Int.add_mul_div_eq (n : Int) {x denom : Int} :
-  denom ≠ 0 → 0 <= x → x < denom → (n * denom + x) / denom = n := fun hne hle hlt => by
+theorem add_mul_div_eq (n : Int) {x denom : Int} :
+  denom ≠ 0 → 0 ≤ x → x < denom → (n * denom + x) / denom = n := fun hne hle hlt => by
   rw [add_comm, mul_comm]
   have hx := Int.add_mul_div_left x n hne
   have hx' : x / denom = 0 := Int.div_eq_zero_of_lt' hle hlt
@@ -386,28 +405,32 @@ theorem Int.add_mul_div_eq (n : Int) {x denom : Int} :
   assumption
 
 @[simp]
-theorem Int.add_mul_div_eq' (n : Int) {x denom : Int} :
-  denom ≠ 0 → 0 <= x → x < denom → (denom * n + x) / denom = n := by
+theorem add_mul_div_eq' (n : Int) {x denom : Int} :
+  denom ≠ 0 → 0 ≤ x → x < denom → (denom * n + x) / denom = n := by
   rw [mul_comm]; exact add_mul_div_eq n
 
 @[simp]
-theorem Int.add_mul_div_eq'' (n : Int) {x denom : Int} :
-  denom ≠ 0 → 0 <= x → x < denom → (x + n * denom) / denom = n := by
+theorem add_mul_div_eq'' (n : Int) {x denom : Int} :
+  denom ≠ 0 → 0 ≤ x → x < denom → (x + n * denom) / denom = n := by
   rw [add_comm]; exact add_mul_div_eq n
 
 @[simp]
-theorem Int.add_mul_div_eq''' (n : Int) {x denom : Int} :
-  denom ≠ 0 → 0 <= x → x < denom → (x + denom * n) / denom = n := by
+theorem add_mul_div_eq''' (n : Int) {x denom : Int} :
+  denom ≠ 0 → 0 ≤ x → x < denom → (x + denom * n) / denom = n := by
   rw [add_comm, mul_comm]; exact add_mul_div_eq n
 
-theorem toOrdinalDate_helper1 : ∀ {x : Int}, 1 <= x → 1 <= x.toNat
+theorem toOrdinalDate_helper1 : ∀ {x : Int}, 1 ≤ x → 1 ≤ x.toNat
 | Int.negSucc _, h => by cases h
 | Int.ofNat xN, h => by
   apply Classical.byContradiction
   intro h'
-  have h_eq_zero : xN = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ (lt_of_not_ge h') : xN <= 0)
+  have h_eq_zero : xN = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ (lt_of_not_ge h') : xN ≤ 0)
   rw [h_eq_zero] at h
   cases h
+
+end Int
+
+
 
 instance {n : Nat} : Lean.ToJson (Fin n) where
   toJson fin :=
@@ -420,20 +443,22 @@ instance {n : Nat} : Lean.FromJson (Fin n) where
     then return Fin.mk val h
     else Except.error s!"Fin.val out of range: {val} is not less than {n}"
 
-/-
-In general, we're only concerned with si powers LE zero,
-because we need to remain coherent with one-second resolutions.
-For any si pow > 0, you end up losing information. E.g. adding a single
-leap second to a DateTime that's in (10^1) resolution is no longer
-a simple operation.
+/-- An `Int`eger `z` such that `z ≤ 0`.
+
+In general, we're only concerned with si powers LE zero, because we need to remain coherent with
+one-second resolutions. For any si `pow > 0`, you end up losing information, *e.g.* adding a single
+leap second to a DateTime that's in `(10^1)` resolution is no longer a simple operation.
 -/
-abbrev NegSiPow := { z : Int // z <= 0 }
+abbrev NegSiPow := { z : Int // z ≤ 0 }
+
 abbrev SiPow := Int
 
-instance : OfNat NegSiPow 0 where
+namespace NegSiPow
+
+instance instOfNatZero : OfNat NegSiPow 0 where
   ofNat := ⟨0, by decide⟩
 
-instance : Coe NegSiPow SiPow where
+instance instCoeSelfSiPow : Coe NegSiPow SiPow where
   coe p := p.val
 
 def minLeft (x : NegSiPow) (y : Int) : NegSiPow :=
@@ -441,14 +466,21 @@ def minLeft (x : NegSiPow) (y : Int) : NegSiPow :=
 
 theorem minLeft_eq  (x : NegSiPow) (y : Int) : (minLeft x y).val = min x.val y := rfl
 
-theorem minLeft_le (x : NegSiPow) (y : Int) : (minLeft x y) <= x := by
+theorem minLeft_le (x : NegSiPow) (y : Int) : (minLeft x y) ≤ x := by
   simp only [minLeft]
   exact min_le_left x.val y
 
-theorem minLeft_eq' (x : NegSiPow) (y : Int) : (minLeft (minLeft x y) (min (↑x) y)) = (minLeft x y) :=
-  have h0 : (minLeft (minLeft x y) (min (↑x) y)).val = (minLeft x y).val := by exact min_self (min (↑x) y)
+theorem minLeft_eq' (x : NegSiPow) (y : Int) :
+  (minLeft (minLeft x y) (min (↑x) y)) = (minLeft x y)
+:=
+  have h0 : (minLeft (minLeft x y) (min (↑x) y)).val = (minLeft x y).val := by
+    exact min_self (min (↑x) y)
   Subtype.val_inj.mp h0
 
 def minRight (y : Int) (x : NegSiPow) : NegSiPow := minLeft x y
 
-theorem minRight_eq (x : NegSiPow) (y : Int) : (minRight y x).val = min x.val y := rfl
+theorem minRight_eq (x : NegSiPow) (y : Int) :
+  (minRight y x).val = min x.val y
+:= rfl
+
+end NegSiPow


### PR DESCRIPTION
Pretty much everything is in the `Timelib` namespace now.


The one exception is `_root_.Int.rataDie` defined in `Timelib/Date/ScalarDate.lean` which still augments the lean `Int` namespace for convenience. Also I think given the definition's name there's little risk of conflict, except maybe when importing another time-related library. Just in case, the definition is now `protected`.

This PR also fixes the proof for `Ymd.is_january_month` in `Timelib/Date/Lemmas/YmdOrdinalEquiv.lean`, thought both files in `Timelib/Date/Lemmas` seem to be imported anywhere and most (all?) proofs in them were broken even before this PR.